### PR TITLE
Use correct string length in examples

### DIFF
--- a/tools/examples/wfa_adapt.c
+++ b/tools/examples/wfa_adapt.c
@@ -48,7 +48,7 @@ int main(int argc,char* argv[]) {
   const int max_distance_threshold = 50;
   // Init Affine-WFA
   affine_wavefronts_t* affine_wavefronts = affine_wavefronts_new_reduced(
-      strlen(pattern),strlen(text),&affine_penalties,
+      strlen(pattern),strlen(pattern),&affine_penalties,
       min_wavefront_length,max_distance_threshold,NULL,mm_allocator);
   // Align
   affine_wavefronts_align(

--- a/tools/examples/wfa_basic.c
+++ b/tools/examples/wfa_basic.c
@@ -46,7 +46,7 @@ int main(int argc,char* argv[]) {
   };
   // Init Affine-WFA
   affine_wavefronts_t* affine_wavefronts = affine_wavefronts_new_complete(
-      strlen(pattern),strlen(text),&affine_penalties,NULL,mm_allocator);
+      strlen(pattern),strlen(pattern),&affine_penalties,NULL,mm_allocator);
   // Align
   affine_wavefronts_align(
       affine_wavefronts,pattern,strlen(pattern),text,strlen(text));

--- a/tools/examples/wfa_repeated.c
+++ b/tools/examples/wfa_repeated.c
@@ -46,7 +46,7 @@ int main(int argc,char* argv[]) {
   };
   // Init Affine-WFA
   affine_wavefronts_t* affine_wavefronts = affine_wavefronts_new_complete(
-      strlen(pattern),strlen(text),&affine_penalties,NULL,mm_allocator);
+      strlen(pattern),strlen(pattern),&affine_penalties,NULL,mm_allocator);
   // Repeat alignment (for the sake of it)
   int i;
   for (i=0;i<100000;++i) {


### PR DESCRIPTION
Tried running your examples and found this minor issue.