### PR TITLE
ensure correct build in parallel by defining object dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,13 @@ all: MODE=all
 all: setup
 all: $(SUBDIRS) tools $(LIB_WFA)
 
+$(FOLDER_BUILD)/*.o: $(SUBDIRS)
+
 debug: setup
 debug: MODE=all
 debug: $(SUBDIRS) tools $(LIB_WFA)
 
-$(LIB_WFA): .FORCE
+$(LIB_WFA): $(FOLDER_BUILD)/*.o
 	$(AR) $(AR_FLAGS) $(LIB_WFA) $(FOLDER_BUILD)/*.o 2> /dev/null
 
 setup:


### PR DESCRIPTION
This is a fix to the makefile to resolve a race condition encountered during parallel builds.