### PR TITLE
explicit the math library to make the examples

### DIFF
--- a/tools/examples/compile.examples.sh
+++ b/tools/examples/compile.examples.sh
@@ -7,6 +7,6 @@ if [ ! -f "../../build/libwfa.a" ]; then
 fi
 
 # Compile examples
-gcc -O3 -I../.. -L../../build wfa_basic.c -o wfa_basic -lwfa
-gcc -O3 -I../.. -L../../build wfa_repeated.c -o wfa_repeated -lwfa
-gcc -O3 -I../.. -L../../build wfa_adapt.c -o wfa_adapt -lwfa
+gcc -O3 -I../.. -L../../build wfa_basic.c -o wfa_basic -lwfa -lm
+gcc -O3 -I../.. -L../../build wfa_repeated.c -o wfa_repeated -lwfa -lm
+gcc -O3 -I../.. -L../../build wfa_adapt.c -o wfa_adapt -lwfa -lm


### PR DESCRIPTION
Hi Santiago,

on my system, I needed to explicit the math library to compile the examples. Take a look.